### PR TITLE
#167- Refactored quiz answer validation

### DIFF
--- a/gameservice/routers/RouterQuestionRetriever.js
+++ b/gameservice/routers/RouterQuestionRetriever.js
@@ -37,9 +37,9 @@ router.get('/game/:subject/:numQuestions?/:numOptions?', async (req, res) => {
             const answers = [q.answer, ...fakeAnswers].sort(() => 0.5 - Math.random());
             
             return {
+                question_id: q._id,
                 image_name: `/images/${q._id}.jpg`,
-                answers,
-                right_answer: q.answer
+                answers
             };
         }));
 
@@ -48,6 +48,24 @@ router.get('/game/:subject/:numQuestions?/:numOptions?', async (req, res) => {
     } catch (error) {
         console.error('Error retrieving questions:', error);
         res.status(500).json({ error: 'Error retrieving questions' });
+    }
+});
+
+router.post('/question/validate', async (req, res) => {
+    try {
+        const { question_id, selected_answer } = req.body;
+
+        const question = await Question.findOne({ _id: question_id }).exec();
+        if (!question) {
+            return res.status(404).json({ error: 'Question not found' });
+        }
+
+        const isCorrect = question.answer === selected_answer;
+        res.json({ isCorrect });
+
+    } catch (error) {
+        console.error('Error validating answer:', error);
+        res.status(500).json({ error: 'Error validating answer' });
     }
 });
 

--- a/gameservice/routers/RouterQuestionRetriever.js
+++ b/gameservice/routers/RouterQuestionRetriever.js
@@ -61,11 +61,36 @@ router.post('/question/validate', async (req, res) => {
         }
 
         const isCorrect = question.answer === selected_answer;
-        res.json({ isCorrect });
+        res.json({
+            isCorrect,
+            correctAnswer: isCorrect ? null : question.answer
+        });
 
     } catch (error) {
         console.error('Error validating answer:', error);
         res.status(500).json({ error: 'Error validating answer' });
+    }
+});
+
+router.post('/game/chat', async (req, res) => {
+    try {
+        const { question_id, message } = req.body;
+
+        const question = await Question.findOne({ _id: question_id }).exec();
+        if (!question) {
+            return res.status(404).json({ error: 'Question not found' });
+        }
+
+        res.json({
+            question_data: {
+                answers: question.answers,
+                right_answer: question.answer
+            }
+        });
+
+    } catch (error) {
+        console.error('Error retrieving question data for chat:', error);
+        res.status(500).json({ error: 'Error retrieving question data' });
     }
 });
 

--- a/gameservice/routers/RouterQuestionRetriever.js
+++ b/gameservice/routers/RouterQuestionRetriever.js
@@ -75,16 +75,18 @@ router.post('/question/validate', async (req, res) => {
 router.post('/game/chat', async (req, res) => {
     try {
         const { question_id, message } = req.body;
-
+        const SALT = "wichatEN2B"; // Temporal, this should be an environmental variable
         const question = await Question.findOne({ _id: question_id }).exec();
         if (!question) {
             return res.status(404).json({ error: 'Question not found' });
         }
 
+        const obfuscatedAnswer = Buffer.from(question.answer + SALT).toString('base64');
+
         res.json({
             question_data: {
                 answers: question.answers,
-                right_answer: question.answer
+                right_answer: obfuscatedAnswer
             }
         });
 

--- a/gameservice/routers/RouterQuestionRetriever.js
+++ b/gameservice/routers/RouterQuestionRetriever.js
@@ -35,7 +35,6 @@ router.get('/game/:subject/:numQuestions?/:numOptions?', async (req, res) => {
 
             // Shuffle the correct answer with the fake answers
             const answers = [q.answer, ...fakeAnswers].sort(() => 0.5 - Math.random());
-            
             return {
                 question_id: q._id,
                 image_name: `/images/${q._id}.jpg`,
@@ -72,26 +71,18 @@ router.post('/question/validate', async (req, res) => {
     }
 });
 
-router.post('/game/chat', async (req, res) => {
+router.get('/question/internal/:id', async (req, res) => {
     try {
-        const { question_id, message } = req.body;
-        const SALT = "wichatEN2B"; // Temporal, this should be an environmental variable
-        const question = await Question.findOne({ _id: question_id }).exec();
+        console.log("Retrieving question data for LLM...");
+        const question = await Question.findOne({ _id: req.params.id }).exec();
         if (!question) {
             return res.status(404).json({ error: 'Question not found' });
         }
-
-        const obfuscatedAnswer = Buffer.from(question.answer + SALT).toString('base64');
-
         res.json({
-            question_data: {
-                answers: question.answers,
-                right_answer: obfuscatedAnswer
-            }
+            right_answer: question.answer
         });
-
     } catch (error) {
-        console.error('Error retrieving question data for chat:', error);
+        console.error('Error retrieving question data:', error);
         res.status(500).json({ error: 'Error retrieving question data' });
     }
 });

--- a/gameservice/routers/RouterQuestionRetriever.test.js
+++ b/gameservice/routers/RouterQuestionRetriever.test.js
@@ -4,18 +4,24 @@ const mongoose = require('mongoose');
 const Question = require('../question-model');
 const router = require('./RouterQuestionRetriever');
 
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongoServer;
+
 const app = express();
 app.use(express.json());
 app.use('/api', router);
 
 describe('RouterQuestionRetriever', () => {
     beforeAll(async () => {
-        const url = `mongodb://127.0.0.1/test_database`;
-        await mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true });
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+        await mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
     });
 
     afterAll(async () => {
-        await mongoose.connection.close();
+        await mongoose.disconnect();
+        await mongoServer.stop();
     });
 
     beforeEach(async () => {
@@ -23,31 +29,31 @@ describe('RouterQuestionRetriever', () => {
     });
     it('should return 3 random questions with 3 options each by default', async () => {
         await Question.insertMany([
-            { subject: 'Math', answer: 'Answer 1' },
-            { subject: 'Math', answer: 'Answer 2' },
-            { subject: 'Math', answer: 'Answer 3' },
-            { subject: 'Math', answer: 'Answer 4' },
-            { subject: 'Math', answer: 'Answer 5' }
+            { _id: new mongoose.Types.ObjectId(), subject: 'Math', answer: 'Answer 1' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Math', answer: 'Answer 2' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Math', answer: 'Answer 3' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Math', answer: 'Answer 4' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Math', answer: 'Answer 5' }
         ]);
 
         const res = await request(app).get('/api/game/Math');
-
+        let expectedAnswers = [];
         expect(res.status).toBe(200);
         expect(res.body.length).toBe(3);
         res.body.forEach(question => {
             expect(question.answers.length).toBe(3);
-            expect(question.answers).toContain(question.right_answer);
+            expect(question.image_name).toBe(`/images/${question.question_id}.jpg`);
         });
     });
 
     it('should return the specified number of questions and options', async () => {
         await Question.insertMany([
-            { subject: 'Science', answer: 'Answer 1' },
-            { subject: 'Science', answer: 'Answer 2' },
-            { subject: 'Science', answer: 'Answer 3' },
-            { subject: 'Science', answer: 'Answer 4' },
-            { subject: 'Science', answer: 'Answer 5' },
-            { subject: 'Science', answer: 'Answer 6' }
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 1' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 2' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 3' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 4' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 5' },
+            { _id: new mongoose.Types.ObjectId(), subject: 'Science', answer: 'Answer 6' }
         ]);
 
         const res = await request(app).get('/api/game/Science/2/4');
@@ -56,13 +62,12 @@ describe('RouterQuestionRetriever', () => {
         expect(res.body.length).toBe(2);
         res.body.forEach(question => {
             expect(question.answers.length).toBe(4);
-            expect(question.answers).toContain(question.right_answer);
         });
     });
-    
+
     it('should return 400 if not enough questions in DB', async () => {
         await Question.insertMany([
-            { subject: 'History', answer: 'Answer 1' }
+            { _id: new mongoose.Types.ObjectId(), subject: 'History', answer: 'Answer 1' }
         ]);
 
         const res = await request(app).get('/api/game/History/3');
@@ -82,4 +87,96 @@ describe('RouterQuestionRetriever', () => {
         expect(res.body.error).toBe('Error retrieving questions');
     });
 
+    // POST /question/validate tests
+    it('should validate correct answer', async () => {
+        const question = await Question.create({
+            _id: new mongoose.Types.ObjectId(),
+            subject: 'Math',
+            answer: 'Mock answer'
+        });
+
+        const res = await request(app)
+            .post('/api/question/validate')
+            .send({
+                question_id: question._id,
+                selected_answer: 'Mock answer'
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+            isCorrect: true,
+            correctAnswer: null
+        });
+    });
+
+    it('should validate incorrect answer', async () => {
+        const question = await Question.create({
+            _id: new mongoose.Types.ObjectId(),
+            subject: 'Math',
+            answer: 'Mock answer'
+        });
+
+        const res = await request(app)
+            .post('/api/question/validate')
+            .send({
+                question_id: question._id,
+                selected_answer: 'Wrong answer'
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+            isCorrect: false,
+            correctAnswer: 'Mock answer'
+        });
+    });
+
+    it('should return 404 for non-existent question', async () => {
+        let question_id = new mongoose.Types.ObjectId();
+        const res = await request(app)
+            .post('/api/question/validate')
+            .send({
+                question_id: question_id,
+                selected_answer: 'Any answer'
+            });
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Question not found');
+    });
+
+    // GET /question/internal/:id tests
+    it('should return right answer for internal use', async () => {
+        const question = await Question.create({
+            _id: new mongoose.Types.ObjectId(),
+            subject: 'Math',
+            answer: 'Mock answer'
+        });
+
+        const res = await request(app)
+            .get(`/api/question/internal/${question._id}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+            right_answer: 'Mock answer'
+        });
+    });
+
+    it('should return 404 for non-existent question', async () => {
+        const res = await request(app)
+            .get(`/api/question/internal/${new mongoose.Types.ObjectId()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Question not found');
+    });
+
+    it('should return 500 on database error', async () => {
+        jest.spyOn(Question, 'findOne').mockImplementationOnce(() => {
+            throw new Error('Database error');
+        });
+
+        const res = await request(app)
+            .get(`/api/question/internal/${new mongoose.Types.ObjectId()}`);
+
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('Error retrieving question data');
+    });
 });

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -136,8 +136,15 @@ app.get('/game/:subject/:totalQuestions/:numberOptions', async (req, res) => {
   }
 });
 app.post('/question/validate', (req, res) => forwardRequest('game', '/question/validate', req, res));
-app.use('/game/chat', publicCors);
-app.post('/game/chat', (req, res) => forwardRequest('game', '/game/chat', req, res));
+
+app.use('/question/internal/:id', cors({
+  origin: serviceUrls.llm,
+  methods: ['GET']
+}));
+
+app.get('/question/internal/:id', (req, res) =>
+    forwardRequest('game', `/question/internal/${req.params.id}`, req, res)
+);
 // Statistics Routes
 ['/statistics/subject/:subject', '/statistics/global', '/leaderboard'].forEach(route => {
   app.use(route, publicCors);

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -113,6 +113,7 @@ app.post('/askllm', (req, res) => forwardRequest('llm', '/askllm', req, res));
 
 // Game Service Routes
 app.use('/game', publicCors);
+app.use('/question/validate', publicCors);
 app.get('/game/:subject/:totalQuestions/:numberOptions', async (req, res) => {
   try {
     const response = await fetch(
@@ -134,6 +135,7 @@ app.get('/game/:subject/:totalQuestions/:numberOptions', async (req, res) => {
     res.status(500).json({ error: 'Hubo un problema al obtener las preguntas' });
   }
 });
+app.post('/question/validate', (req, res) => forwardRequest('game', '/question/validate', req, res));
 
 // Statistics Routes
 ['/statistics/subject/:subject', '/statistics/global', '/leaderboard'].forEach(route => {

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -136,7 +136,8 @@ app.get('/game/:subject/:totalQuestions/:numberOptions', async (req, res) => {
   }
 });
 app.post('/question/validate', (req, res) => forwardRequest('game', '/question/validate', req, res));
-
+app.use('/game/chat', publicCors);
+app.post('/game/chat', (req, res) => forwardRequest('game', '/game/chat', req, res));
 // Statistics Routes
 ['/statistics/subject/:subject', '/statistics/global', '/leaderboard'].forEach(route => {
   app.use(route, publicCors);

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -33,7 +33,7 @@ const llmConfigs = {
           content: "You are an assistant designed to help players during a quiz game. When a player asks for a hint, "
             + "you will provide a helpful clue related to the question, but not the full answer."
             + " The possible answers are: " + answer.answers.join(",") + "."
-            + " The right answer is: " + answer.right_answer + "."
+            + " The right answer is: " + Buffer.from(answer.right_answer, 'base64').toString().replace("wichatEN2B", "")  + "."
             + " You will never give the correct answer."
         },
         ...messages 

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -2,6 +2,8 @@ const axios = require('axios');
 const express = require('express');
 const helmet = require('helmet')
 
+const apiEndpoint = process.env.GATEWAY_SERVICE_URL || 'http://gatewayservice:8000';
+
 const app = express();
 
 app.use(helmet());
@@ -25,7 +27,7 @@ const llmConfigs = {
   },
   empathy: {
     url: () => 'https://empathyai.prod.empathy.co/v1/chat/completions',
-    transformRequest: (messages, answer) => ({
+    transformRequest: (messages, answer, questionResponse) => ({
       model: "mistralai/Mistral-7B-Instruct-v0.3",
       messages: [
         { 
@@ -33,7 +35,7 @@ const llmConfigs = {
           content: "You are an assistant designed to help players during a quiz game. When a player asks for a hint, "
             + "you will provide a helpful clue related to the question, but not the full answer."
             + " The possible answers are: " + answer.answers.join(",") + "."
-            + " The right answer is: " + Buffer.from(answer.right_answer, 'base64').toString().replace("wichatEN2B", "")  + "."
+            + " The right answer is: " + questionResponse.data.right_answer + "."
             + " You will never give the correct answer."
         },
         ...messages 
@@ -59,13 +61,14 @@ function validateRequiredFields(req, requiredFields) {
 // Function to send questions to LLM
 async function sendQuestionToLLM(conversation, apiKey, answer, model = 'empathy') {
   try {
+    const questionResponse = await axios.get(`${apiEndpoint}/question/internal/${answer.question_id}`);
+
     const config = llmConfigs[model];
     if (!config) {
       throw new Error(`Model "${model}" is not supported.`);
     }
-    
 
-    const requestData = config.transformRequest(conversation, answer);
+    const requestData = config.transformRequest(conversation, answer, questionResponse);
     
     const headers = {
       'Content-Type': 'application/json',
@@ -74,7 +77,7 @@ async function sendQuestionToLLM(conversation, apiKey, answer, model = 'empathy'
 
     const url = config.url(apiKey);
 
-     const filterWords = answer.answers;  
+     const filterWords = answer.answers;
 
      let response;
      let llmAnswer;

--- a/webapp/src/components/game/InGameChat.js
+++ b/webapp/src/components/game/InGameChat.js
@@ -35,22 +35,13 @@ export default function InGameChat(params) {
         setIsThinking(true);
 
         try {
-            const questionDataResponse = await fetch(`${apiEndpoint}/game/chat`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    question_id: question.question_id,
-                    message: input
-                })
-            });
-            const questionData = await questionDataResponse.json();
             const response = await fetch(`${apiEndpoint}/askllm`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     conversation: [{ role: "user", content: input }],
                     model: "empathy",
-                    possibleAnswers: { answers: question.answers, right_answer: questionData.question_data.right_answer }
+                    possibleAnswers: question
                 })
             });
             const data = await response.json();

--- a/webapp/src/components/game/InGameChat.js
+++ b/webapp/src/components/game/InGameChat.js
@@ -32,17 +32,25 @@ export default function InGameChat(params) {
 
         setMessages(prevMessages => [...prevMessages, newMessage]);
         setInput("");
-
         setIsThinking(true);
 
         try {
+            const questionDataResponse = await fetch(`${apiEndpoint}/game/chat`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    question_id: question.question_id,
+                    message: input
+                })
+            });
+            const questionData = await questionDataResponse.json();
             const response = await fetch(`${apiEndpoint}/askllm`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     conversation: [{ role: "user", content: input }],
                     model: "empathy",
-                    possibleAnswers: { answers: question.answers, right_answer: question.right_answer }
+                    possibleAnswers: { answers: question.answers, right_answer: questionData.question_data.right_answer }
                 })
             });
             const data = await response.json();

--- a/webapp/src/components/game/QuestionGame.js
+++ b/webapp/src/components/game/QuestionGame.js
@@ -95,7 +95,6 @@ export default function QuestionGame(params) {
                 ...prevAnswers,
                 {
                     answer: option,
-                    right_answer: questions[currentQuestion].right_answer,
                     isCorrect: isCorrect,
                     points: calculatePoints(isCorrect),
                     timeSpent: timerDuration - timeLeft,
@@ -198,7 +197,7 @@ export default function QuestionGame(params) {
                                 key={option}
                                 className={`quiz-option 
                                 ${selectedOption === option ? "selected" : ""} 
-                                ${selectedOption !== null && option === questions[currentQuestion].right_answer ? "correct-answer" : ""}`}
+                                ${selectedOption === option && isRight ? "correct-answer" : ""}`}
                                 onClick={() => handleOptionSelect(option)}
                                 disabled={selectedOption !== null}>
                                 {option}

--- a/webapp/src/components/game/QuestionGame.js
+++ b/webapp/src/components/game/QuestionGame.js
@@ -9,7 +9,7 @@ const apiEndpoint = process.env.NEXT_PUBLIC_GATEWAY_SERVICE_URL || 'http://local
 
 export default function QuestionGame(params) {
     const { topic, subject, totalQuestions, numberOptions, timerDuration, question } = params;
-
+    const [correctAnswer, setCorrectAnswer] = useState(null);
     const [currentQuestion, setCurrentQuestion] = useState(0);
     const [questions, setQuestions] = useState([]);
     const [isWrong, setIsWrong] = useState(false);
@@ -86,10 +86,11 @@ export default function QuestionGame(params) {
                 })
             });
 
-            const { isCorrect } = await response.json();
+            const { isCorrect, correctAnswer } = await response.json();
 
             setIsRight(isCorrect);
             setIsWrong(!isCorrect);
+            setCorrectAnswer(correctAnswer);
 
             setAnswers((prevAnswers) => [
                 ...prevAnswers,
@@ -129,6 +130,7 @@ export default function QuestionGame(params) {
         setIsWrong(false);
         setSelectedOption(null);
         setTimeLeft(timerDuration);
+        setCorrectAnswer(null);
     };
 
     useEffect(() => {
@@ -197,7 +199,8 @@ export default function QuestionGame(params) {
                                 key={option}
                                 className={`quiz-option 
                                 ${selectedOption === option ? "selected" : ""} 
-                                ${selectedOption === option && isRight ? "correct-answer" : ""}`}
+                                ${selectedOption === option && isRight ? "correct-answer" : ""}
+                                ${!isRight && correctAnswer === option ? "correct-answer" : ""}`}
                                 onClick={() => handleOptionSelect(option)}
                                 disabled={selectedOption !== null}>
                                 {option}

--- a/webapp/src/tests/QuestionGame.test.js
+++ b/webapp/src/tests/QuestionGame.test.js
@@ -20,12 +20,12 @@ describe('QuestionGame component', () => {
         {
             image_name: '/images/sample1.jpg',
             answers: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
-            right_answer: 'Option 1'
+            question_id: '1'
         },
         {
             image_name: '/images/sample2.jpg',
             answers: ['A', 'B', 'C', 'D'],
-            right_answer: 'B'
+            question_id: '2'
         }
     ];
 
@@ -57,12 +57,14 @@ describe('QuestionGame component', () => {
 
     it('handles option selection and moves to the next question', async () => {
         fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
+
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={30} />);
 
         await waitFor(() => screen.getByText(/Question 1 of/));
 
         fireEvent.click(screen.getByText('Option 1'));
-        expect(screen.getByText('Great job! You got it right!')).toBeInTheDocument();
+        await waitFor(() => expect(screen.getByText('Great job! You got it right!')).toBeInTheDocument());
 
         act(() => jest.advanceTimersByTime(2000));
         await waitFor(() => screen.getByText(/Question 2 of/));
@@ -70,26 +72,35 @@ describe('QuestionGame component', () => {
 
     it('handles incorrect option selection', async () => {
         fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: false, correctAnswer: 'Option 1' }));
+
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={30} />);
 
         await waitFor(() => screen.getByText(/Question 1 of/));
 
         fireEvent.click(screen.getByText('Option 2'));
-        expect(screen.getByText(/Oops! You didn't guess this one./)).toBeInTheDocument();
+        await waitFor(() => expect(screen.getByText(/Oops! You didn't guess this one./)).toBeInTheDocument());
     });
 
     it('displays final results at the end of the game', async () => {
         fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
+
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={30} />);
 
         await waitFor(() => screen.getByText(/Question 1 of/));
+
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
         fireEvent.click(screen.getByText('Option 1'));
         // A bit more than 2 seconds so that the next question is loaded before checking
+        await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
+
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
 
         await waitFor(() => screen.getByText(/Question 2 of/));
         fireEvent.click(screen.getByText('B'));
         // A bit more than 2 seconds so that the next question is loaded before checking
+        await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
 
         await waitFor(() => screen.getByText('Quiz Completed!'));
@@ -100,7 +111,7 @@ describe('QuestionGame component', () => {
     it('handles the timer running out', async () => {
         jest.useFakeTimers(); // Enable fake timers
         fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
-
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: false, correctAnswer: 'Option 1' }));
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={5} />);
 
         // Wait for the first question to appear
@@ -114,14 +125,22 @@ describe('QuestionGame component', () => {
 
     it('restarts the game when "Play again" is clicked', async () => {
         fetchMock.mockResponse(JSON.stringify(mockQuestions));
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
+
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={30} />);
 
         await waitFor(() => screen.getByText(/Question 1 of/));
         fireEvent.click(screen.getByText('Option 1'));
+        await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
+
         fireEvent.click(screen.getByText('B'));
+        await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
         await waitFor(() => screen.getByText('Quiz Completed!'));
+
+        fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
 
         fireEvent.click(screen.getByText('Play again'));
         await waitFor(() => screen.getByText(/Question 1 of/));

--- a/webapp/src/tests/QuestionGame.test.js
+++ b/webapp/src/tests/QuestionGame.test.js
@@ -124,9 +124,12 @@ describe('QuestionGame component', () => {
     });
 
     it('restarts the game when "Play again" is clicked', async () => {
-        fetchMock.mockResponse(JSON.stringify(mockQuestions));
-        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
-        fetchMock.mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }));
+        fetchMock
+            .mockResponseOnce(JSON.stringify(mockQuestions))
+            .mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }))
+            .mockResponseOnce(JSON.stringify({ isCorrect: true, correctAnswer: null }))
+            .mockResponseOnce(JSON.stringify({})) // Save game results mock
+            .mockResponseOnce(JSON.stringify(mockQuestions));
 
         render(<QuestionGame topic="1" subject="test" totalQuestions={2} numberOptions={4} timerDuration={30} />);
 
@@ -135,14 +138,14 @@ describe('QuestionGame component', () => {
         await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
 
+        await waitFor(() => screen.getByText(/Question 2 of/));
         fireEvent.click(screen.getByText('B'));
         await waitFor(() => screen.getByText('Great job! You got it right!'));
         act(() => jest.advanceTimersByTime(2050));
+
         await waitFor(() => screen.getByText('Quiz Completed!'));
-
-        fetchMock.mockResponseOnce(JSON.stringify(mockQuestions));
-
         fireEvent.click(screen.getByText('Play again'));
+
         await waitFor(() => screen.getByText(/Question 1 of/));
     });
 });


### PR DESCRIPTION
# Overview
This PR includes all the changes performed to delegate answer validation to the backend. After this change, there's no way the user can see the right answers through inspect mode:
![image](https://github.com/user-attachments/assets/024b850e-db7d-4e7c-b878-e1abc5e17338)

## Changes made
* QuestionGame no longer receives the right answer from the RouterQuestionRetriever. It only receives the image name, the possible answers and the question ID.
* The question ID and the user's selected answer is passed to a new endpoint `/question/validate` in RouterQuestionRetriever which returns a boolean (isCorrect).
* The LLM chat no longer uses the right answer provided by QuestionGame, since it has no access to this value. A new endpoint `/question/internal/:id` has been created in RouterQuestionRetriever which provides the right answer for a given id. Only the LLM service can communicate with this endpoint through the gateway.
* Some tests have been refactored to accomodate to new changes and new cases have been developed.
